### PR TITLE
Make normalization of evaluation times optional (default:False)

### DIFF
--- a/survstack/functional.py
+++ b/survstack/functional.py
@@ -128,7 +128,7 @@ def _encode_onehot(times: np.ndarray, n_samples: int) -> np.ndarray:
     return np.tile(np.eye(times.shape[0]), (n_samples, 1))
 
 
-def _encode_continuous(times: np.ndarray, n_samples: int, normalize: bool = True) -> np.ndarray:
+def _encode_continuous(times: np.ndarray, n_samples: int, normalize: bool = False) -> np.ndarray:
     """Tile a (optionally normalized) time vector for continuous time encoding."""
     if normalize:
         times = times / times[-1]

--- a/survstack/functional.py
+++ b/survstack/functional.py
@@ -128,9 +128,11 @@ def _encode_onehot(times: np.ndarray, n_samples: int) -> np.ndarray:
     return np.tile(np.eye(times.shape[0]), (n_samples, 1))
 
 
-def _encode_continuous(times: np.ndarray, n_samples: int) -> np.ndarray:
-    """Tile a normalized time vector for continuous time encoding."""
-    return np.tile(times / times[-1], n_samples).reshape(-1, 1)
+def _encode_continuous(times: np.ndarray, n_samples: int, normalize: bool = True) -> np.ndarray:
+    """Tile a (optionally normalized) time vector for continuous time encoding."""
+    if normalize:
+        times = times / times[-1]
+    return np.tile(times, n_samples).reshape(-1, 1)
 
 
 def cumulative_hazard_function(estimates: np.ndarray, times: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
When using continuous time, evaluation time horizons were being normalized to `t~Unif(0,1)` which is different than the time distribution of time in train stack data either raw or post normalization.

Best practice is to keep time raw in the test eval stacked data and transform using the same scaler as with the training data (if any). 
